### PR TITLE
Fixed SET in SQLite 3

### DIFF
--- a/sqlish.js
+++ b/sqlish.js
@@ -1238,7 +1238,7 @@
 		if (this.sql.verb !== "UPDATE") {
 			throw "SQL doesn't support SET except in UPDATE";
 		}
-		set(nameOrObject, value);
+		set.call(this, nameOrObject, value);
 		return this;
 	};
 	Dialects["SQLite 3"].into = function () {


### PR DESCRIPTION
I've noticed that #set doesn't work on SQLite 3 dialect because it's called without a context being set.

This patch should fix everything (yep, it's just one line of code :P)
